### PR TITLE
Use Dublin Core properties in common entity clause translation

### DIFF
--- a/doc/obo-syntax.html
+++ b/doc/obo-syntax.html
@@ -1915,12 +1915,10 @@ The following qualifiers are not translated to annotations:
 <td valign="top" style="white-space: pre;">obo:IAO_0100001</td>
 </tr>
 
-
 <tr>
 <td valign="top" style="white-space: pre;">consider</td>
 <td valign="top" style="white-space: pre; color:red">oboInOwl:consider</td>
 </tr>
-
 
 <tr>
 <td valign="top" style="white-space: pre;">hasScope</td>
@@ -1980,6 +1978,16 @@ The following qualifiers are not translated to annotations:
 <tr>
 <td valign="top" style="white-space: pre;">shorthand</td>
 <td valign="top" style="white-space: pre; color:red">oboInOwl:shorthand</td>
+</tr>
+	
+<tr>
+<td valign="top" style="white-space: pre;">created_by</td>
+<td valign="top" style="white-space: pre; color:red">dc:creator</td>
+</tr>
+	
+<tr>
+<td valign="top" style="white-space: pre;">creation_date</td>
+<td valign="top" style="white-space: pre; color:red">dc:date</td>
 </tr>
 
 </tbody>


### PR DESCRIPTION
Currently, the OWL API or whatever converter the GO is using exports `creation_date` and `created_by` as `oboInOwl:creation_date` and `oboInOwl:created_by`, both of which are undefined. 

Instead, I believe they shoud be mapped to `dc:date` and `dc:creator` respectively, which would help with RDF translation.

I left them in red in case the spec is updated again since this is WIP.