### PR TITLE
Make `xref` use `oboInOwl` annotation property

### DIFF
--- a/doc/obo-syntax.html
+++ b/doc/obo-syntax.html
@@ -1957,7 +1957,7 @@ The following qualifiers are not translated to annotations:
 
 <tr>
 <td valign="top" style="white-space: pre;">xref</td>
-<td valign="top" style="white-space: pre; color:red">oboInOwl:xref</td>
+<td valign="top" style="white-space: pre; color:red">oboInOwl:hasDbXref</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Currently the translation for an xref is `oboInOwl:xref` which does not exist. `oboInOwl:DbXref` is a term so it should not be used as an annotation property; `oboInOwl:hasDbXref` should be used instead. 

It would also be a good idea to make `oboInOwl` declare `hasDbXref` as a `rdfs:seeAlso` equivalent (using an xref clause as described in [section 5.9.3](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#5.9.3)), which is does not currently, for better integration with OWL and RDF. See #110.