### PR TITLE
Add `all_some` and `all_only` to untranslated qualifiers

### DIFF
--- a/doc/obo-syntax.html
+++ b/doc/obo-syntax.html
@@ -1829,6 +1829,8 @@ The following qualifiers are not translated to annotations:
  <li>maxCardinality</li>
  <li>gci_relation</li>
  <li>gci_filler</li>
+ <li>all_some</li>
+ <li>all_only</li>
 </ul>
 </div>
 


### PR DESCRIPTION
These two qualifiers are used to translate `intersection_of` and `relationship` clauses into the right OWL class expression, so they should not appear in the final OWL document.